### PR TITLE
If present the beta version will appear also in the documentation page

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -1,6 +1,7 @@
 current:
 - 2.9.3
 # uncomment this to add beta release:
+# the doc link works only if the beta ends in b
 beta: 2.10b
 old:
 - 2.8.4

--- a/doc.md
+++ b/doc.md
@@ -8,6 +8,12 @@ __Documentation for recent releases__
 {% endfor %}
 
 __Documentation for development version__
+{% if site.data.releases.beta %}
+{% assign ver=site.data.releases.beta | split: 'b'%}
+{% assign ver=ver[0] | split: '.'%}
+{% assign ver[1]= ver[1] | slice: 0,-1 %}
+{% assign vers= ver[0] | append: '.' | append: ver[1] %}
+* [Beta version {{ vers }}b](http://plumed.github.io/doc-v{{ vers }}/user-doc/html/index.html){% endif %}
 * [Development version](http://plumed.github.io/doc-master/user-doc/html/index.html)
 
 __Documentation for previous, unsupported releases__


### PR DESCRIPTION
Works like for the download
I just needed to manipulate the "b" away from the version to link to the correct doc site.

And I did that I a way that only one with 0 jekyll/liquid knowledge could do